### PR TITLE
feat: add form data and file upload support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test go code
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '**.go'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
       exclude-functions:
         - fmt.Fprintln
         - fmt.Fprintf
+        - fmt.Fprint
     wrapcheck:
       ignore-package-globs:
         - encoding/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: v1.0.0-rc.1
     hooks:
-      - id: golangci-lint
+      - id: golangci-lint-mod
       - id: go-mod-tidy

--- a/README.md
+++ b/README.md
@@ -368,8 +368,8 @@ Here is how it looks, a GitHub webhook (trimmed, masked due to it’s huge/priva
     {"action":"created","issue":{"url": ...} ... }
     ----------------------------------------------------------------------------------------------------
 
-If you are checking secret token/secret token header (`test`, `X-Gitlab-Token`), 
-you’ll see something like this in Payload section:
+If you are checking secret token/secret token header (`test`, `X-Gitlab-Token`),
+you'll see something like this in Payload section:
 
     +-----------------------------------+-----------------------------+
     | Payload                                                         |                                                                                                                                    |
@@ -378,6 +378,67 @@ you’ll see something like this in Payload section:
     | Secret Token Header Name          | X-Gitlab-Token              |
     | Secret Token Matches?             | true                        |
     +-----------------------------------+-----------------------------+
+
+---
+
+## Form Data Support
+
+The debugger supports `application/x-www-form-urlencoded` content type. Form
+data is parsed and displayed in a table format:
+
+```bash
+curl -X POST http://localhost:9002/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=john&password=secret123&remember=true"
+```
+
+Output:
+
+    +-----------------------------------------------------+
+    | Payload                                             |
+    +--------------+--------------------------------------+
+    | Incoming     | application/x-www-form-urlencoded    |
+    +--------------+--------------------------------------+
+    | Form Data                                           |
+    +--------------+--------------------------------------+
+    | password     | secret123                            |
+    | remember     | true                                 |
+    | username     | john                                 |
+    +--------------+--------------------------------------+
+
+Form fields are sorted alphabetically. Multiple values for the same key are
+displayed comma-separated:
+
+```bash
+curl -X POST http://localhost:9002/colors \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "color=red&color=green&color=blue"
+```
+
+Output:
+
+    +--------------+--------------------------------------+
+    | Form Data                                           |
+    +--------------+--------------------------------------+
+    | color        | red, green, blue                     |
+    +--------------+--------------------------------------+
+
+URL-encoded special characters are automatically decoded:
+
+```bash
+curl -X POST http://localhost:9002/search \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "email=user%40example.com&query=hello+world"
+```
+
+Output:
+
+    +--------------+--------------------------------------+
+    | Form Data                                           |
+    +--------------+--------------------------------------+
+    | email        | user@example.com                     |
+    | query        | hello world                          |
+    +--------------+--------------------------------------+
 
 ---
 
@@ -450,6 +511,13 @@ rake test               # run test
 
 ## Change Log
 
+**2026-01-23**
+
+- add `application/x-www-form-urlencoded` content type support
+- form data is parsed and displayed in table format
+- multiple values for the same key are comma-separated
+- URL-encoded characters are automatically decoded
+
 **2025-01-23**
 
 - add web dashboard for real-time request monitoring (similar to ngrok)
@@ -489,7 +557,6 @@ rake test               # run test
 
 ## TODO
 
-- Add http form requests support
 - Add http file upload requests support
 
 ---

--- a/README.md
+++ b/README.md
@@ -442,6 +442,72 @@ Output:
 
 ---
 
+## File Upload Support
+
+The debugger supports `multipart/form-data` content type for file uploads.
+Both form fields and files are parsed and displayed:
+
+```bash
+curl -X POST http://localhost:9002/upload \
+  -F "username=vigo" \
+  -F "description=Test upload" \
+  -F "config=@config.json"
+```
+
+Output:
+
+    +-----------------------------------------------------+
+    | Payload                                             |
+    +--------------+--------------------------------------+
+    | Incoming     | multipart/form-data; boundary=...    |
+    +--------------+--------------------------------------+
+    | Form Data                                           |
+    +--------------+--------------------------------------+
+    | description  | Test upload                          |
+    | username     | vigo                                 |
+    +--------------+--------------------------------------+
+    | Files                                               |
+    +--------------+--------------------------------------+
+    | config.json | 18 B | application/json               |
+    | {"theme": "dark"}                                   |
+    +-----------------------------------------------------+
+
+File metadata is displayed for all uploaded files:
+
+```bash
+curl -X POST http://localhost:9002/upload \
+  -F "avatar=@photo.png"
+```
+
+Output:
+
+    +-----------------------------------------------------+
+    | Files                                               |
+    +-----------------------------------------------------+
+    | photo.png | 2.5 KB | application/octet-stream       |
+    +-----------------------------------------------------+
+
+For small text files (under 1KB), the content is displayed. For larger files
+or binary files, only metadata (filename, size, content-type) is shown.
+
+**Image Preview in Web Dashboard:** When you upload image files (JPEG, PNG, GIF,
+etc.), the web dashboard displays a preview of the image alongside the file
+metadata.
+
+Multiple files can be uploaded at once:
+
+```bash
+curl -X POST http://localhost:9002/upload \
+  -F "file1=@readme.txt" \
+  -F "file2=@data.json" \
+  -F "image=@logo.png"
+```
+
+Form fields and files are displayed in separate sections, both in the terminal
+and in the web dashboard.
+
+---
+
 ## Docker
 
 For local docker usage, default expose port is: `9002` (debug) and `9003` (web dashboard).
@@ -514,9 +580,15 @@ rake test               # run test
 **2026-01-23**
 
 - add `application/x-www-form-urlencoded` content type support
+- add `multipart/form-data` content type support for file uploads
 - form data is parsed and displayed in table format
+- file uploads show metadata (filename, size, content-type)
+- small text files (under 1KB) display content inline
 - multiple values for the same key are comma-separated
 - URL-encoded characters are automatically decoded
+- web dashboard supports form data and file upload display
+- web dashboard shows image preview for uploaded images (JPEG, PNG, GIF, etc.)
+- binary file content is sanitized in terminal output (`[binary data: X KB]`)
 
 **2025-01-23**
 
@@ -557,7 +629,7 @@ rake test               # run test
 
 ## TODO
 
-- Add http file upload requests support
+- Add brew tap installation support
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Start the server;
 basichttpdebugger                   # listens at :9002
 ```
 
+> **Note:** The URL path doesn't matter. The server captures **all** incoming
+> requests regardless of the path. `http://localhost:9002/`,
+> `http://localhost:9002/webhook`, `http://localhost:9002/api/v1/users` - they
+> all work the same way. The paths used in examples below (`/login`, `/upload`,
+> etc.) are just for illustration purposes.
+
 Listen different port:
 
 ```bash

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -641,8 +641,13 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 			fmt.Fprintf(mwr, "%s: %s\n", key, strings.Join(r.Header[key], ","))
 		}
 		if bodyAsString != "" {
+			// Terminal gets sanitized body (no binary garbage)
 			sanitizedBody := sanitizeBodyForDisplay(bodyAsString, r.Header.Get(headerContentType))
-			fmt.Fprintf(mwr, "\n%s\n", sanitizedBody)
+			fmt.Fprintf(options.writer, "\n%s\n", sanitizedBody)
+			// Raw file gets unsanitized body (for replay with nc)
+			if rawHRw != nil {
+				fmt.Fprintf(rawHRw, "\n%s\n", bodyAsString)
+			}
 		}
 		options.drawLine()
 		if rawHRw != nil {

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -48,7 +48,8 @@ const (
 	defTerminalWidth     = 80
 
 	headerContentType   = "Content-Type"
-	asciiSpaceThreshold = 32 // ASCII control characters below this are non-printable
+	asciiSpaceThreshold = 32      // ASCII control characters below this are non-printable
+	maxImagePreviewSize = 5 << 20 // 5MB max for image preview in WebUI
 )
 
 // VerboseServer defines server behaviours.
@@ -504,7 +505,8 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 						}
 
 						// Store raw data for images (for WebUI preview)
-						if isImageContentType(fi.ContentType) {
+						// Only store if under maxImagePreviewSize to prevent memory issues
+						if isImageContentType(fi.ContentType) && fi.Size <= maxImagePreviewSize {
 							fi.RawData = partData
 						}
 

--- a/internal/httpserver/run.go
+++ b/internal/httpserver/run.go
@@ -116,8 +116,8 @@ func Run() error {
 			log.Printf("web dashboard stop error: %v", webErr)
 		}
 
-		if err = server.Stop(); err != nil {
-			log.Printf("server stop error: %v", err)
+		if stopErr := server.Stop(); stopErr != nil {
+			log.Printf("server stop error: %v", stopErr)
 		}
 
 		close(closed)

--- a/internal/requeststore/store.go
+++ b/internal/requeststore/store.go
@@ -9,6 +9,15 @@ import (
 
 const defaultMaxSize = 50
 
+// FileAttachment represents an uploaded file with base64 encoded data.
+type FileAttachment struct {
+	FieldName   string `json:"fieldName"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	Size        int    `json:"size"`
+	Data        string `json:"data,omitempty"` // base64 encoded for images
+}
+
 // Request represents a captured HTTP request.
 type Request struct {
 	ID      string            `json:"id"`
@@ -19,6 +28,7 @@ type Request struct {
 	Body    string            `json:"body"`
 	Host    string            `json:"host"`
 	Proto   string            `json:"proto"`
+	Files   []FileAttachment  `json:"files,omitempty"`
 }
 
 // Store holds captured requests in memory with pub/sub support for SSE.

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -967,13 +967,14 @@
             }
         }
 
+        let initialLoadDone = false;
+
         function connectSSE() {
             eventSource = new EventSource('/events');
 
             eventSource.onopen = () => {
                 setStatus(true);
-                // Load initial requests after SSE is connected
-                loadInitialRequests();
+                // Don't reload here - initial load already done, avoids race condition
             };
 
             eventSource.onmessage = (event) => {
@@ -988,15 +989,19 @@
             eventSource.onerror = () => {
                 setStatus(false);
                 eventSource.close();
-                // Load requests even if SSE fails (fallback)
-                loadInitialRequests();
+                // Only load if never loaded before (SSE failed on first connect)
+                if (!initialLoadDone) {
+                    loadInitialRequests().then(() => { initialLoadDone = true; });
+                }
                 setTimeout(connectSSE, 3000);
             };
         }
 
-        // Load initial requests immediately on page load
-        loadInitialRequests();
-        connectSSE();
+        // Load initial requests BEFORE connecting SSE to avoid race condition
+        loadInitialRequests().then(() => {
+            initialLoadDone = true;
+            connectSSE();
+        });
     </script>
 </body>
 </html>

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -541,6 +541,15 @@
             return ct.toLowerCase().startsWith('image/');
         }
 
+        // Whitelist of safe image content types to prevent XSS via malicious Content-Type headers
+        const SAFE_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/x-icon'];
+
+        function sanitizeImageContentType(ct) {
+            if (!ct) return 'application/octet-stream';
+            const normalized = ct.toLowerCase().split(';')[0].trim();
+            return SAFE_IMAGE_TYPES.includes(normalized) ? normalized : 'application/octet-stream';
+        }
+
         function binaryStringToBase64(str) {
             // Convert binary string to base64
             try {
@@ -664,8 +673,10 @@
                     let fileInfoContent = `${escapeHtml(file.filename)} | ${sizeStr} | ${escapeHtml(file.contentType)}`;
 
                     // Show image preview if we have base64 data (in same cell)
+                    // Use sanitized content-type to prevent XSS via malicious headers
                     if (file.data && isImageContentType(file.contentType)) {
-                        const dataUrl = `data:${file.contentType};base64,${file.data}`;
+                        const safeContentType = sanitizeImageContentType(file.contentType);
+                        const dataUrl = `data:${safeContentType};base64,${file.data}`;
                         fileInfoContent += `<div class="image-preview"><img src="${dataUrl}" alt="${escapeHtml(file.filename)}" /></div>`;
                     }
 

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -51,7 +51,7 @@
 
         header {
             background: var(--bg-secondary);
-            padding: 1rem 1.5rem;
+            padding: 1rem;
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -300,6 +300,39 @@
             font-style: italic;
         }
 
+        .form-data-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.875rem;
+        }
+
+        .form-data-table th {
+            text-align: left;
+            padding: 0.5rem 0.75rem;
+            background: var(--bg-tertiary);
+            color: var(--text-muted);
+            font-weight: 600;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .form-data-table td {
+            padding: 0.5rem 0.75rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .form-data-table td:first-child {
+            color: var(--accent);
+            font-weight: 500;
+            width: 200px;
+        }
+
+        .form-data-table tr:last-child td {
+            border-bottom: none;
+        }
+
         .detail-header {
             display: flex;
             justify-content: space-between;
@@ -470,20 +503,58 @@
         }
 
         function formatBody(body, headers) {
-            if (!body) return '<span class="no-body">No body</span>';
+            if (!body) return { type: 'text', content: '<span class="no-body">No body</span>' };
 
             const contentType = headers['Content-Type'] || headers['content-type'] || '';
 
             if (contentType.includes('application/json')) {
                 try {
                     const parsed = JSON.parse(body);
-                    return escapeHtml(JSON.stringify(parsed, null, 2));
+                    return { type: 'text', content: escapeHtml(JSON.stringify(parsed, null, 2)) };
                 } catch (e) {
-                    return escapeHtml(body);
+                    return { type: 'text', content: escapeHtml(body) };
                 }
             }
 
-            return escapeHtml(body);
+            if (contentType.includes('application/x-www-form-urlencoded')) {
+                try {
+                    const params = new URLSearchParams(body);
+                    const entries = [...params.entries()];
+
+                    if (entries.length === 0) {
+                        return { type: 'text', content: '<span class="no-body">Empty form</span>' };
+                    }
+
+                    // Group values by key for multiple values
+                    const grouped = {};
+                    for (const [key, value] of entries) {
+                        if (!grouped[key]) {
+                            grouped[key] = [];
+                        }
+                        grouped[key].push(value);
+                    }
+
+                    const sortedKeys = Object.keys(grouped).sort();
+                    const rows = sortedKeys.map(key => {
+                        const values = grouped[key].join(', ');
+                        return `<tr><td>${escapeHtml(key)}</td><td>${escapeHtml(values)}</td></tr>`;
+                    }).join('');
+
+                    return { type: 'form', content: `<table class="form-data-table"><thead><tr><th>Field</th><th>Value</th></tr></thead><tbody>${rows}</tbody></table>` };
+                } catch (e) {
+                    return { type: 'text', content: escapeHtml(body) };
+                }
+            }
+
+            return { type: 'text', content: escapeHtml(body) };
+        }
+
+        function renderBodyContent(body, headers) {
+            const formatted = formatBody(body, headers);
+            if (formatted.type === 'form') {
+                return formatted.content;
+            }
+            return `<div class="body-content">${formatted.content}</div>`;
         }
 
         function renderRequestList() {
@@ -571,7 +642,7 @@
 
                 <div class="detail-section">
                     <h3>Body</h3>
-                    <div class="body-content">${formatBody(req.body, headers)}</div>
+                    ${renderBodyContent(req.body, headers)}
                 </div>
             `;
 
@@ -648,10 +719,29 @@
             statusText.textContent = connected ? 'Connected' : 'Disconnected';
         }
 
+        async function loadInitialRequests() {
+            try {
+                const response = await fetch('/api/requests');
+                const data = await response.json();
+                requests = data || [];
+                renderRequestList();
+
+                if (requests.length > 0) {
+                    selectRequest(requests[0].id);
+                }
+            } catch (e) {
+                console.error('Failed to load requests:', e);
+            }
+        }
+
         function connectSSE() {
             eventSource = new EventSource('/events');
 
-            eventSource.onopen = () => setStatus(true);
+            eventSource.onopen = () => {
+                setStatus(true);
+                // Load initial requests after SSE is connected
+                loadInitialRequests();
+            };
 
             eventSource.onmessage = (event) => {
                 try {
@@ -669,22 +759,6 @@
             };
         }
 
-        async function loadInitialRequests() {
-            try {
-                const response = await fetch('/api/requests');
-                const data = await response.json();
-                requests = data || [];
-                renderRequestList();
-
-                if (requests.length > 0) {
-                    selectRequest(requests[0].id);
-                }
-            } catch (e) {
-                console.error('Failed to load requests:', e);
-            }
-        }
-
-        loadInitialRequests();
         connectSSE();
     </script>
 </body>

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -988,10 +988,14 @@
             eventSource.onerror = () => {
                 setStatus(false);
                 eventSource.close();
+                // Load requests even if SSE fails (fallback)
+                loadInitialRequests();
                 setTimeout(connectSSE, 3000);
             };
         }
 
+        // Load initial requests immediately on page load
+        loadInitialRequests();
         connectSSE();
     </script>
 </body>

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -327,10 +327,25 @@
             color: var(--accent);
             font-weight: 500;
             width: 200px;
+            vertical-align: top;
         }
 
         .form-data-table tr:last-child td {
             border-bottom: none;
+        }
+
+        .image-preview {
+            padding: 0.5rem;
+            margin-top: 1rem;
+            background: var(--bg-code);
+            border-radius: 6px;
+        }
+
+        .image-preview img {
+            max-width: 100%;
+            max-height: 300px;
+            border-radius: 4px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
         }
 
         .detail-header {
@@ -502,10 +517,177 @@
             return div.innerHTML;
         }
 
-        function formatBody(body, headers) {
-            if (!body) return { type: 'text', content: '<span class="no-body">No body</span>' };
+        function formatFileSize(bytes) {
+            if (bytes >= 1024 * 1024) {
+                return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+            } else if (bytes >= 1024) {
+                return (bytes / 1024).toFixed(1) + ' KB';
+            }
+            return bytes + ' B';
+        }
 
+        function isTextContentType(ct) {
+            if (!ct) return false;
+            ct = ct.toLowerCase();
+            return ct.startsWith('text/') ||
+                   ct.includes('json') ||
+                   ct.includes('xml') ||
+                   ct.includes('javascript') ||
+                   ct.includes('x-www-form-urlencoded');
+        }
+
+        function isImageContentType(ct) {
+            if (!ct) return false;
+            return ct.toLowerCase().startsWith('image/');
+        }
+
+        function binaryStringToBase64(str) {
+            // Convert binary string to base64
+            try {
+                const bytes = new Uint8Array(str.length);
+                for (let i = 0; i < str.length; i++) {
+                    bytes[i] = str.charCodeAt(i) & 0xff;
+                }
+                let binary = '';
+                for (let i = 0; i < bytes.length; i++) {
+                    binary += String.fromCharCode(bytes[i]);
+                }
+                return btoa(binary);
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function parseMultipart(body, contentType) {
+            // Extract boundary from Content-Type
+            const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^;\s]+))/);
+            if (!boundaryMatch) return null;
+            const boundary = boundaryMatch[1] || boundaryMatch[2];
+
+            const fields = [];
+            const files = [];
+
+            // Split by boundary
+            const parts = body.split('--' + boundary);
+
+            for (const part of parts) {
+                if (part.trim() === '' || part.trim() === '--') continue;
+
+                // Split headers from content (double CRLF or double LF)
+                const headerEndIdx = part.indexOf('\r\n\r\n');
+                const headerEndIdxLF = part.indexOf('\n\n');
+                let headers, content;
+
+                if (headerEndIdx !== -1) {
+                    headers = part.substring(0, headerEndIdx);
+                    content = part.substring(headerEndIdx + 4);
+                } else if (headerEndIdxLF !== -1) {
+                    headers = part.substring(0, headerEndIdxLF);
+                    content = part.substring(headerEndIdxLF + 2);
+                } else {
+                    continue;
+                }
+
+                // Remove trailing boundary markers
+                content = content.replace(/\r?\n?--$/, '').replace(/\r?\n$/, '');
+
+                // Parse Content-Disposition
+                const dispositionMatch = headers.match(/Content-Disposition:\s*form-data;\s*name="([^"]+)"(?:;\s*filename="([^"]+)")?/i);
+                if (!dispositionMatch) continue;
+
+                const fieldName = dispositionMatch[1];
+                const filename = dispositionMatch[2];
+
+                if (filename) {
+                    // File field
+                    const ctMatch = headers.match(/Content-Type:\s*([^\r\n]+)/i);
+                    const fileContentType = ctMatch ? ctMatch[1].trim() : 'application/octet-stream';
+
+                    let fileContent = null;
+                    let imageDataUrl = null;
+
+                    if (isTextContentType(fileContentType)) {
+                        fileContent = content;
+                    } else if (isImageContentType(fileContentType)) {
+                        const base64 = binaryStringToBase64(content);
+                        if (base64) {
+                            imageDataUrl = `data:${fileContentType};base64,${base64}`;
+                        }
+                    }
+
+                    files.push({
+                        name: fieldName,
+                        filename: filename,
+                        contentType: fileContentType,
+                        size: content.length,
+                        content: fileContent,
+                        imageDataUrl: imageDataUrl
+                    });
+                } else {
+                    // Regular form field
+                    fields.push({ name: fieldName, value: content });
+                }
+            }
+
+            return { fields, files };
+        }
+
+        function formatMultipartWithFiles(body, contentType, files) {
+            let html = '';
+
+            // Parse form fields from body if it's multipart
+            if (contentType.includes('multipart/form-data') && body) {
+                const parsed = parseMultipart(body, contentType);
+                if (parsed && parsed.fields.length > 0) {
+                    const grouped = {};
+                    for (const field of parsed.fields) {
+                        if (!grouped[field.name]) {
+                            grouped[field.name] = [];
+                        }
+                        grouped[field.name].push(field.value);
+                    }
+
+                    const sortedKeys = Object.keys(grouped).sort();
+                    const fieldRows = sortedKeys.map(key => {
+                        const values = grouped[key].join(', ');
+                        return `<tr><td>${escapeHtml(key)}</td><td>${escapeHtml(values)}</td></tr>`;
+                    }).join('');
+
+                    html += `<table class="form-data-table"><thead><tr><th>Field</th><th>Value</th></tr></thead><tbody>${fieldRows}</tbody></table>`;
+                }
+            }
+
+            // Show files from server-provided array
+            if (files.length > 0) {
+                const fileRows = files.map(file => {
+                    const sizeStr = formatFileSize(file.size);
+                    let fileInfoContent = `${escapeHtml(file.filename)} | ${sizeStr} | ${escapeHtml(file.contentType)}`;
+
+                    // Show image preview if we have base64 data (in same cell)
+                    if (file.data && isImageContentType(file.contentType)) {
+                        const dataUrl = `data:${file.contentType};base64,${file.data}`;
+                        fileInfoContent += `<div class="image-preview"><img src="${dataUrl}" alt="${escapeHtml(file.filename)}" /></div>`;
+                    }
+
+                    return `<tr><td>${escapeHtml(file.fieldName)}</td><td>${fileInfoContent}</td></tr>`;
+                }).join('');
+
+                if (html) html += '<div style="margin-top: 1rem;"></div>';
+                html += `<table class="form-data-table"><thead><tr><th>File Field</th><th>File Info</th></tr></thead><tbody>${fileRows}</tbody></table>`;
+            }
+
+            return { type: 'form', content: html || '<span class="no-body">Empty multipart form</span>' };
+        }
+
+        function formatBody(body, headers, files) {
             const contentType = headers['Content-Type'] || headers['content-type'] || '';
+
+            // If we have server-provided files, use them directly for multipart
+            if (files && files.length > 0) {
+                return formatMultipartWithFiles(body, contentType, files);
+            }
+
+            if (!body) return { type: 'text', content: '<span class="no-body">No body</span>' };
 
             if (contentType.includes('application/json')) {
                 try {
@@ -546,11 +728,62 @@
                 }
             }
 
+            if (contentType.includes('multipart/form-data')) {
+                try {
+                    const parsed = parseMultipart(body, contentType);
+                    if (!parsed) {
+                        return { type: 'text', content: escapeHtml(body) };
+                    }
+
+                    let html = '';
+
+                    // Show form fields
+                    if (parsed.fields.length > 0) {
+                        const grouped = {};
+                        for (const field of parsed.fields) {
+                            if (!grouped[field.name]) {
+                                grouped[field.name] = [];
+                            }
+                            grouped[field.name].push(field.value);
+                        }
+
+                        const sortedKeys = Object.keys(grouped).sort();
+                        const fieldRows = sortedKeys.map(key => {
+                            const values = grouped[key].join(', ');
+                            return `<tr><td>${escapeHtml(key)}</td><td>${escapeHtml(values)}</td></tr>`;
+                        }).join('');
+
+                        html += `<table class="form-data-table"><thead><tr><th>Field</th><th>Value</th></tr></thead><tbody>${fieldRows}</tbody></table>`;
+                    }
+
+                    // Show files
+                    if (parsed.files.length > 0) {
+                        const fileRows = parsed.files.map(file => {
+                            const sizeStr = formatFileSize(file.size);
+                            let row = `<tr><td>${escapeHtml(file.name)}</td><td>${escapeHtml(file.filename)} | ${sizeStr} | ${escapeHtml(file.contentType)}</td></tr>`;
+                            if (file.content && file.size <= 1024) {
+                                row += `<tr><td colspan="2"><div class="body-content">${escapeHtml(file.content)}</div></td></tr>`;
+                            } else if (file.imageDataUrl) {
+                                row += `<tr><td colspan="2"><div class="image-preview"><img src="${file.imageDataUrl}" alt="${escapeHtml(file.filename)}" /></div></td></tr>`;
+                            }
+                            return row;
+                        }).join('');
+
+                        if (html) html += '<div style="margin-top: 1rem;"></div>';
+                        html += `<table class="form-data-table"><thead><tr><th>File Field</th><th>File Info</th></tr></thead><tbody>${fileRows}</tbody></table>`;
+                    }
+
+                    return { type: 'form', content: html || '<span class="no-body">Empty multipart form</span>' };
+                } catch (e) {
+                    return { type: 'text', content: escapeHtml(body) };
+                }
+            }
+
             return { type: 'text', content: escapeHtml(body) };
         }
 
-        function renderBodyContent(body, headers) {
-            const formatted = formatBody(body, headers);
+        function renderBodyContent(body, headers, files) {
+            const formatted = formatBody(body, headers, files);
             if (formatted.type === 'form') {
                 return formatted.content;
             }
@@ -642,7 +875,7 @@
 
                 <div class="detail-section">
                     <h3>Body</h3>
-                    ${renderBodyContent(req.body, headers)}
+                    ${renderBodyContent(req.body, headers, req.files)}
                 </div>
             `;
 

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -133,6 +133,10 @@ func (w *WebUI) eventsHandler(rw http.ResponseWriter, r *http.Request) {
 	ch := w.store.Subscribe()
 	defer w.store.Unsubscribe(ch)
 
+	// Send initial comment to establish connection
+	_, _ = fmt.Fprint(rw, ": connected\n\n")
+	flusher.Flush()
+
 	for {
 		select {
 		case req := <-ch:

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -134,7 +134,7 @@ func (w *WebUI) eventsHandler(rw http.ResponseWriter, r *http.Request) {
 	defer w.store.Unsubscribe(ch)
 
 	// Send initial comment to establish connection
-	_, _ = fmt.Fprint(rw, ": connected\n\n")
+	fmt.Fprint(rw, ": connected\n\n")
 	flusher.Flush()
 
 	for {


### PR DESCRIPTION
## Summary

- Add `application/x-www-form-urlencoded` content type support
- Add `multipart/form-data` content type support for file uploads
- Display form data and file metadata in terminal and web dashboard
- Show image preview in web dashboard for uploaded images (JPEG, PNG, GIF, etc.)
- Sanitize binary content in raw HTTP output to avoid terminal garbage

## Changes

- **httpserver.go**: Parse form data and multipart requests, extract files with base64 encoding for images
- **requeststore/store.go**: Add `FileAttachment` struct and `Files` field to `Request`
- **webui/static/index.html**: Display form data tables, file info, and image previews
- **README.md**: Document new features with curl examples

## Test plan

- [x] Run `go test -race ./...` - all tests pass
- [x] Run `golangci-lint run ./...` - no issues
- [x] Manual test: form urlencoded data displays correctly
- [x] Manual test: multipart form data with files displays correctly
- [x] Manual test: image preview shows in web dashboard
- [x] Manual test: binary data shows as `[binary data: X KB]` in terminal

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)