### PR TITLE
fix: handle Content-Type with charset parameter for JSON payload

### DIFF
--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -366,7 +366,17 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 
 			bodyAsString = string(body)
 
-			mediaType, mediaParams, _ := mime.ParseMediaType(requestContentType)
+			mediaType, mediaParams, mediaErr := mime.ParseMediaType(requestContentType)
+			if mediaErr != nil && requestContentType != "" {
+				txtErrorMedia := colorError.Sprintf("mime.ParseMediaType error: %s", mediaErr.Error())
+				t.AppendRow(table.Row{txtErrorMedia, txtErrorMedia}, table.RowConfig{
+					AutoMerge:      true,
+					AutoMergeAlign: text.AlignLeft,
+				})
+				t.AppendSeparator()
+
+				goto RENDER
+			}
 
 			switch mediaType {
 			case "application/json":

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -391,6 +391,8 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 					})
 					t.AppendSeparator()
 
+					payloadAfterTable = bodyAsString
+
 					goto RENDER
 				}
 
@@ -402,6 +404,8 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 						AutoMergeAlign: text.AlignLeft,
 					})
 					t.AppendSeparator()
+
+					payloadAfterTable = bodyAsString
 
 					goto RENDER
 				}

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -366,9 +366,11 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 
 			bodyAsString = string(body)
 
-			switch {
-			case strings.HasPrefix(requestContentType, "application/json"):
-				var jsonBody map[string]any
+			mediaType, mediaParams, _ := mime.ParseMediaType(requestContentType)
+
+			switch mediaType {
+			case "application/json":
+				var jsonBody any
 				if err = json.Unmarshal(body, &jsonBody); err != nil {
 					txtErrorUnmarshal := colorError.Sprintf("json.Unmarshal error: %s", err.Error())
 					t.AppendRow(table.Row{txtErrorUnmarshal, txtErrorUnmarshal}, table.RowConfig{
@@ -393,7 +395,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 				}
 
 				payloadAfterTable = string(prettyJSON)
-			case strings.HasPrefix(requestContentType, "application/x-www-form-urlencoded"):
+			case "application/x-www-form-urlencoded":
 				formData, errForm := url.ParseQuery(bodyAsString)
 				if errForm != nil {
 					txtErrorForm := colorError.Sprintf("url.ParseQuery error: %s", errForm.Error())
@@ -424,20 +426,8 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 					valueStr := colorPayload.Sprint(strings.Join(values, ", "))
 					t.AppendRow(table.Row{key, valueStr})
 				}
-			case strings.HasPrefix(requestContentType, "multipart/form-data"):
-				_, params, errMedia := mime.ParseMediaType(requestContentType)
-				if errMedia != nil {
-					txtErrorMedia := colorError.Sprintf("mime.ParseMediaType error: %s", errMedia.Error())
-					t.AppendRow(table.Row{txtErrorMedia, txtErrorMedia}, table.RowConfig{
-						AutoMerge:      true,
-						AutoMergeAlign: text.AlignLeft,
-					})
-					t.AppendSeparator()
-
-					goto RENDER
-				}
-
-				boundary := params["boundary"]
+			case "multipart/form-data":
+				boundary := mediaParams["boundary"]
 				if boundary == "" {
 					txtErrorBoundary := colorError.Sprint("multipart boundary not found")
 					t.AppendRow(table.Row{txtErrorBoundary, txtErrorBoundary}, table.RowConfig{

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -300,6 +300,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 
 		var bodyAsString string
 		var storeFiles []requeststore.FileAttachment
+		var payloadAfterTable string
 
 		switch r.Method {
 		case http.MethodPost, http.MethodPut, http.MethodPatch:
@@ -391,12 +392,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 					goto RENDER
 				}
 
-				t.AppendSeparator()
-				payloadJSON := colorPayload.Sprintf("%s", prettyJSON)
-				t.AppendRow(table.Row{payloadJSON, payloadJSON}, table.RowConfig{
-					AutoMerge:      true,
-					AutoMergeAlign: text.AlignLeft,
-				})
+				payloadAfterTable = string(prettyJSON)
 			case strings.HasPrefix(requestContentType, "application/x-www-form-urlencoded"):
 				formData, errForm := url.ParseQuery(bodyAsString)
 				if errForm != nil {
@@ -600,19 +596,17 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 					storeFiles = append(storeFiles, sf)
 				}
 			default:
-				payloadText := colorPayload.Sprintf("%s", body)
-				t.AppendSeparator()
-				t.AppendRow(
-					table.Row{payloadText, payloadText},
-					table.RowConfig{
-						AutoMerge:      true,
-						AutoMergeAlign: text.AlignLeft,
-					},
-				)
+				payloadAfterTable = bodyAsString
 			}
 		}
 	RENDER:
 		t.Render()
+
+		if payloadAfterTable != "" {
+			options.drawLine()
+			fmt.Fprintln(options.writer, colorPayload.Sprintf("%s", payloadAfterTable))
+			options.drawLine()
+		}
 
 		mwr := io.MultiWriter(options.writer)
 		var rawHRw *os.File

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -375,6 +375,8 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 				})
 				t.AppendSeparator()
 
+				payloadAfterTable = bodyAsString
+
 				goto RENDER
 			}
 

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -18,7 +18,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -292,7 +292,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 		for key := range r.Header {
 			headerKeys = append(headerKeys, key)
 		}
-		sort.Strings(headerKeys)
+		slices.Sort(headerKeys)
 
 		for _, key := range headerKeys {
 			t.AppendRow(table.Row{key, strings.Join(r.Header[key], ",")})
@@ -366,7 +366,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 			bodyAsString = string(body)
 
 			switch {
-			case requestContentType == "application/json":
+			case strings.HasPrefix(requestContentType, "application/json"):
 				var jsonBody map[string]any
 				if err = json.Unmarshal(body, &jsonBody); err != nil {
 					txtErrorUnmarshal := colorError.Sprintf("json.Unmarshal error: %s", err.Error())
@@ -421,7 +421,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 				for key := range formData {
 					formKeys = append(formKeys, key)
 				}
-				sort.Strings(formKeys)
+				slices.Sort(formKeys)
 
 				for _, key := range formKeys {
 					values := formData[key]
@@ -549,7 +549,7 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 					for key := range formFields {
 						fieldKeys = append(fieldKeys, key)
 					}
-					sort.Strings(fieldKeys)
+					slices.Sort(fieldKeys)
 
 					for _, key := range fieldKeys {
 						values := formFields[key]
@@ -628,7 +628,8 @@ func debugHandlerFunc(options *debugHandlerOptions) http.HandlerFunc {
 			}
 
 			mwr = io.MultiWriter(options.writer, rawHRw)
-			fmt.Fprintf(w, "Raw HTTP Request is saved to: %s\n", formattedFilename)
+			// response is text/plain and filename is sanitized in stringutils.GetFormattedFilename
+			fmt.Fprintf(w, "Raw HTTP Request is saved to: %s\n", formattedFilename) //nolint:gosec
 		}
 
 	WRITERHR:
@@ -855,7 +856,7 @@ func sanitizeBodyForDisplay(body, contentType string) string {
 			// Remove trailing boundary markers for size calculation
 			cleanContent := strings.TrimSuffix(content, "\r\n")
 			cleanContent = strings.TrimSuffix(cleanContent, "\n")
-			result.WriteString(fmt.Sprintf("[binary data: %s]", formatFileSize(len(cleanContent))))
+			fmt.Fprintf(&result, "[binary data: %s]", formatFileSize(len(cleanContent)))
 			// Preserve the trailing newlines
 			if strings.HasSuffix(content, "\r\n") {
 				result.WriteString("\r\n")

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -242,6 +242,44 @@ func TestDebugHandler(t *testing.T) {
 		assert.Contains(t, s, body)
 	})
 
+	t.Run("POST request with malformed Content-Type reports parse error", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.log")
+		server, err := httpserver.New(httpserver.WithOutputWriter(out))
+		require.NoError(t, err)
+
+		body := `whatever`
+		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json; charset=") // missing param value
+		rec := httptest.NewRecorder()
+
+		server.HTTPServer.Handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		got, errR := os.ReadFile(out)
+		require.NoError(t, errR)
+		assert.Contains(t, string(got), "mime.ParseMediaType error")
+	})
+
+	t.Run("POST request with empty Content-Type does not report parse error", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.log")
+		server, err := httpserver.New(httpserver.WithOutputWriter(out))
+		require.NoError(t, err)
+
+		body := `raw payload without content type`
+		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+		req.Header.Del("Content-Type")
+		rec := httptest.NewRecorder()
+
+		server.HTTPServer.Handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		got, errR := os.ReadFile(out)
+		require.NoError(t, errR)
+		s := string(got)
+		assert.NotContains(t, s, "mime.ParseMediaType error")
+		assert.Contains(t, s, body)
+	})
+
 	t.Run("POST request with invalid JSON and charset reports unmarshal error", func(t *testing.T) {
 		out := filepath.Join(t.TempDir(), "out.log")
 		server, err := httpserver.New(httpserver.WithOutputWriter(out))

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -306,6 +306,7 @@ func TestDebugHandler(t *testing.T) {
 		s := string(got)
 
 		assert.Contains(t, s, "json.Unmarshal error")
+		assert.Contains(t, s, body) // raw body still rendered below the table
 	})
 
 	t.Run("POST request with plain text body", func(t *testing.T) {

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -257,7 +257,9 @@ func TestDebugHandler(t *testing.T) {
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)
-		assert.Contains(t, string(got), "mime.ParseMediaType error")
+		s := string(got)
+		assert.Contains(t, s, "mime.ParseMediaType error")
+		assert.Contains(t, s, body) // body still rendered below the table
 	})
 
 	t.Run("POST request with empty Content-Type does not report parse error", func(t *testing.T) {

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -176,6 +176,35 @@ func TestDebugHandler(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "OK")
 	})
 
+	t.Run("POST request with JSON body and charset", func(t *testing.T) {
+		server, err := httpserver.New()
+		require.NoError(t, err)
+
+		body := `{"name": "test", "value": 123}`
+		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		rec := httptest.NewRecorder()
+
+		server.HTTPServer.Handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "OK")
+	})
+
+	t.Run("POST request with invalid JSON and charset falls back gracefully", func(t *testing.T) {
+		server, err := httpserver.New()
+		require.NoError(t, err)
+
+		body := `not-valid-json`
+		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		rec := httptest.NewRecorder()
+
+		server.HTTPServer.Handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
 	t.Run("POST request with plain text body", func(t *testing.T) {
 		server, err := httpserver.New()
 		require.NoError(t, err)

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -189,6 +189,7 @@ func TestDebugHandler(t *testing.T) {
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, server.OutputWriter.Close())
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)
@@ -212,6 +213,7 @@ func TestDebugHandler(t *testing.T) {
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, server.OutputWriter.Close())
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)
@@ -233,6 +235,7 @@ func TestDebugHandler(t *testing.T) {
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, server.OutputWriter.Close())
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)
@@ -254,6 +257,7 @@ func TestDebugHandler(t *testing.T) {
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, server.OutputWriter.Close())
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)
@@ -274,6 +278,7 @@ func TestDebugHandler(t *testing.T) {
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, server.OutputWriter.Close())
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)
@@ -294,6 +299,7 @@ func TestDebugHandler(t *testing.T) {
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, server.OutputWriter.Close())
 
 		got, errR := os.ReadFile(out)
 		require.NoError(t, errR)

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -176,23 +177,74 @@ func TestDebugHandler(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "OK")
 	})
 
-	t.Run("POST request with JSON body and charset", func(t *testing.T) {
-		server, err := httpserver.New()
+	t.Run("POST request with JSON body and charset pretty-prints below the table", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.log")
+		server, err := httpserver.New(httpserver.WithOutputWriter(out))
 		require.NoError(t, err)
 
-		body := `{"name": "test", "value": 123}`
+		body := `{"name":"test","value":123}`
 		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		rec := httptest.NewRecorder()
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
 
-		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Contains(t, rec.Body.String(), "OK")
+		got, errR := os.ReadFile(out)
+		require.NoError(t, errR)
+		s := string(got)
+
+		assert.Contains(t, s, "application/json; charset=utf-8")
+		assert.Contains(t, s, "\"name\": \"test\"")
+		assert.Contains(t, s, "\"value\": 123")
+		assert.NotContains(t, s, "json.Unmarshal error")
 	})
 
-	t.Run("POST request with invalid JSON and charset falls back gracefully", func(t *testing.T) {
-		server, err := httpserver.New()
+	t.Run("POST request with JSON array body pretty-prints", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.log")
+		server, err := httpserver.New(httpserver.WithOutputWriter(out))
+		require.NoError(t, err)
+
+		body := `[1,2,3]`
+		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		server.HTTPServer.Handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		got, errR := os.ReadFile(out)
+		require.NoError(t, errR)
+		s := string(got)
+
+		assert.NotContains(t, s, "json.Unmarshal error")
+		assert.Contains(t, s, "[\n    1,\n    2,\n    3\n]")
+	})
+
+	t.Run("POST request with json-patch+json is not parsed as JSON", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.log")
+		server, err := httpserver.New(httpserver.WithOutputWriter(out))
+		require.NoError(t, err)
+
+		body := `[{"op":"add","path":"/foo","value":"bar"}]`
+		req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json-patch+json")
+		rec := httptest.NewRecorder()
+
+		server.HTTPServer.Handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		got, errR := os.ReadFile(out)
+		require.NoError(t, errR)
+		s := string(got)
+
+		assert.NotContains(t, s, "json.Unmarshal error")
+		assert.Contains(t, s, body)
+	})
+
+	t.Run("POST request with invalid JSON and charset reports unmarshal error", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.log")
+		server, err := httpserver.New(httpserver.WithOutputWriter(out))
 		require.NoError(t, err)
 
 		body := `not-valid-json`
@@ -201,8 +253,13 @@ func TestDebugHandler(t *testing.T) {
 		rec := httptest.NewRecorder()
 
 		server.HTTPServer.Handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
 
-		assert.Equal(t, http.StatusOK, rec.Code)
+		got, errR := os.ReadFile(out)
+		require.NoError(t, errR)
+		s := string(got)
+
+		assert.Contains(t, s, "json.Unmarshal error")
 	})
 
 	t.Run("POST request with plain text body", func(t *testing.T) {

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -300,6 +300,65 @@
             font-style: italic;
         }
 
+        .section-title {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.5rem;
+        }
+
+        .copy-btn {
+            background: var(--bg-tertiary);
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            padding: 0.25rem 0.6rem;
+            font-size: 0.75rem;
+            font-family: inherit;
+            cursor: pointer;
+            transition: background 0.15s, color 0.15s, border-color 0.15s;
+            line-height: 1;
+            white-space: nowrap;
+        }
+
+        .copy-btn:hover {
+            background: var(--accent);
+            color: #fff;
+            border-color: var(--accent);
+        }
+
+        .copy-btn.copied {
+            background: #4ade80;
+            color: #0d1117;
+            border-color: #4ade80;
+        }
+
+        .headers-table .header-value-cell {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 0.5rem;
+        }
+
+        .headers-table .header-value-text {
+            flex: 1;
+            min-width: 0;
+            word-break: break-all;
+        }
+
+        .headers-table .copy-btn {
+            padding: 0.1rem 0.45rem;
+            font-size: 0.7rem;
+            opacity: 0;
+            transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+            flex-shrink: 0;
+        }
+
+        .headers-table tr:hover .copy-btn,
+        .headers-table .copy-btn.copied {
+            opacity: 1;
+        }
+
         .form-data-table {
             width: 100%;
             border-collapse: collapse;
@@ -515,6 +574,59 @@
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        function copyToClipboard(text) {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                return navigator.clipboard.writeText(text);
+            }
+            return new Promise((resolve, reject) => {
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                ta.setAttribute('readonly', '');
+                ta.style.position = 'absolute';
+                ta.style.left = '-9999px';
+                document.body.appendChild(ta);
+                ta.select();
+                try {
+                    document.execCommand('copy') ? resolve() : reject(new Error('copy command failed'));
+                } catch (e) {
+                    reject(e);
+                } finally {
+                    document.body.removeChild(ta);
+                }
+            });
+        }
+
+        function flashCopied(btn) {
+            const original = btn.textContent;
+            btn.textContent = 'Copied!';
+            btn.classList.add('copied');
+            clearTimeout(btn._copyTimer);
+            btn._copyTimer = setTimeout(() => {
+                btn.textContent = original;
+                btn.classList.remove('copied');
+            }, 1500);
+        }
+
+        function wireCopyButtons(root) {
+            root.querySelectorAll('.copy-header-value').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const cell = btn.closest('.header-value-cell');
+                    const span = cell ? cell.querySelector('.header-value-text') : null;
+                    const text = span ? span.textContent : '';
+                    copyToClipboard(text).then(() => flashCopied(btn)).catch(err => console.error('copy failed:', err));
+                });
+            });
+
+            const bodyBtn = root.querySelector('#copyBodyBtn');
+            if (bodyBtn) {
+                bodyBtn.addEventListener('click', () => {
+                    const target = root.querySelector('.body-section-content');
+                    const text = target ? target.textContent.trim() : '';
+                    copyToClipboard(text).then(() => flashCopied(bodyBtn)).catch(err => console.error('copy failed:', err));
+                });
+            }
         }
 
         function formatFileSize(bytes) {
@@ -838,9 +950,15 @@
                 .map(([key, value]) => `
                     <tr>
                         <td>${escapeHtml(key)}</td>
-                        <td>${escapeHtml(value)}</td>
+                        <td>
+                            <div class="header-value-cell">
+                                <span class="header-value-text">${escapeHtml(value)}</span>
+                                <button class="copy-btn copy-header-value" type="button" title="Copy value">Copy</button>
+                            </div>
+                        </td>
                     </tr>
                 `).join('');
+            const hasBody = !!req.body || (req.files && req.files.length > 0);
 
             detail.innerHTML = `
                 <div class="detail-header">
@@ -885,12 +1003,16 @@
                 </div>
 
                 <div class="detail-section">
-                    <h3>Body</h3>
-                    ${renderBodyContent(req.body, headers, req.files)}
+                    <div class="section-title">
+                        <h3>Body</h3>
+                        ${hasBody ? '<button class="copy-btn" id="copyBodyBtn" type="button" title="Copy body">Copy</button>' : ''}
+                    </div>
+                    <div class="body-section-content">${renderBodyContent(req.body, headers, req.files)}</div>
                 </div>
             `;
 
             document.getElementById('replayBtn').addEventListener('click', () => replayRequest(req.id));
+            wireCopyButtons(detail);
             detail.style.display = 'block';
         }
 

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -263,12 +263,16 @@
         }
 
         .headers-table {
-            width: 100%;
+            width: auto;
             font-size: 0.875rem;
         }
 
         .headers-table tr {
             border-bottom: 1px solid var(--border-color);
+        }
+        
+        .headers-table tr:hover {
+            background-color: white;
         }
 
         .headers-table td {

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -640,7 +640,7 @@
             if (bodyBtn) {
                 bodyBtn.addEventListener('click', () => {
                     const target = root.querySelector('.body-section-content');
-                    const text = target ? target.textContent.trim() : '';
+                    const text = target ? target.textContent : '';
                     copyToClipboard(text).then(() => flashCopied(bodyBtn)).catch(err => console.error('copy failed:', err));
                 });
             }

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -370,6 +370,12 @@
             outline-offset: 2px;
         }
 
+        @media (hover: none) {
+            .headers-table .copy-btn {
+                opacity: 1;
+            }
+        }
+
         .form-data-table {
             width: 100%;
             border-collapse: collapse;

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -272,7 +272,7 @@
         }
         
         .headers-table tr:hover {
-            background-color: white;
+            background-color: var(--highlight-bg);
         }
 
         .headers-table td {
@@ -359,8 +359,15 @@
         }
 
         .headers-table tr:hover .copy-btn,
+        .headers-table tr:focus-within .copy-btn,
+        .headers-table .copy-btn:focus-visible,
         .headers-table .copy-btn.copied {
             opacity: 1;
+        }
+
+        .copy-btn:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
         }
 
         .form-data-table {


### PR DESCRIPTION
## Summary

Originally a Content-Type charset bug fix; grew during review into a small bundle of related fixes plus a Web UI quality-of-life feature.

### httpserver
- Switch JSON Content-Type matching to `mime.ParseMediaType` + a tagged switch on the parsed media type. Requests like `application/json; charset=utf-8` are now correctly routed to the JSON branch, while `application/json-patch+json` / `application/jsonp` (and any other type whose subtype merely starts with `json`) no longer get misrouted into JSON parsing.
- Surface `mime.ParseMediaType` errors on a non-empty Content-Type instead of swallowing them; an absent Content-Type still falls through to raw body as before.
- Switch the JSON unmarshal target from `map[string]any` to `any`, so arrays and primitives (e.g. JSON Patch arrays, `[1,2,3]`, `"hello"`) pretty-print instead of failing with `cannot unmarshal array into Go value of type map[string]any`.
- Render JSON / raw-text payloads outside the table. Long lines inside an AutoMerge'd payload row (e.g. an Azure DevOps webhook with a long URL) were inflating column 1's max width on narrow terminals, pushing values past the terminal edge so 2-column rows looked empty. The body now sits below the table, framed by separator lines.
- On `json.Unmarshal` / `json.MarshalIndent` / `mime.ParseMediaType` error paths, still set `payloadAfterTable = bodyAsString` so the raw body is visible even when classification fails.
- Pre-existing lint touched along the way: `sort.Strings` → `slices.Sort`, `WriteString(fmt.Sprintf(...))` → `fmt.Fprintf`, and a `//nolint:gosec` with rationale on a `text/plain` response Fprintf flagged by G705.

### Web dashboard
- Add a "Copy" button next to the Body section heading that copies the displayed body text (raw text or pretty-printed JSON) to the clipboard.
- Each row in the Headers table gets an inline copy button revealed on hover / `:focus-within` / `:focus-visible`, and stays visible on touch devices via `@media (hover: none)`. Buttons flash a "Copied!" confirmation for 1.5s.
- Replace a hard-coded `background-color: white` on `.headers-table tr:hover` (pre-existing) with `var(--highlight-bg)` so the dark theme keeps usable contrast.

### Tests
- New table-driven coverage exercises observable handler output through `WithOutputWriter` to a temp file: charset-suffixed JSON pretty-prints below the table, JSON arrays pretty-print, `application/json-patch+json` is **not** parsed as JSON, malformed Content-Type surfaces a parse error while still showing the raw body, empty Content-Type does not, and invalid JSON shows the unmarshal error plus the raw body.
- Subtests close `server.OutputWriter` before reading the temp file to avoid potential file-locking failures on Windows and ensure writes are flushed before assertions.

## Test plan
- [x] `go test ./...` passes
- [x] Pre-commit `golangci-lint-mod` + `go-mod-tidy` passes
- [x] Manual: Body copy + per-header copy buttons verified in the dashboard via Playwright (clipboard receives correct text, "Copied!" feedback toggles)
- [ ] Verify final Codecov + Copilot feedback after CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)